### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://ramonrossi.visualstudio.com/5495ffb1-174e-4552-b249-1b1bba99b5dc/febf30ce-085c-4aa0-a6aa-a737426a173c/_apis/work/boardbadge/cfd7a54d-aff2-4115-82fb-465e8b0dcec1)](https://ramonrossi.visualstudio.com/5495ffb1-174e-4552-b249-1b1bba99b5dc/_boards/board/t/febf30ce-085c-4aa0-a6aa-a737426a173c/Microsoft.RequirementCategory)
 # daily-do
 daily python challenges


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://ramonrossi.visualstudio.com/5495ffb1-174e-4552-b249-1b1bba99b5dc/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.